### PR TITLE
Add AGENTS.md and opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/big-pickle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+GitHub profile repository. No build, test, or lint tooling.
+
+- CI generates GitHub Snake animation to `dist/github-snake.svg`
+- Automated via `.github/workflows/ci.yml` (daily schedule + push to main)
+- No application code, dependencies, or traditional dev workflow


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with repository-specific guidance for OpenCode sessions
- Add `.github/workflows/opencode.yml` to enable OpenCode CI integration

## Details
- `AGENTS.md` provides compact instructions for future agents working in this repo
- OpenCode workflow triggers on `/oc` or `/opencode` comments in issues and PRs