### PR TITLE
Fix opencode workflow permissions

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -8,13 +8,17 @@ on:
 
 jobs:
   opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
-    if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
     permissions:
+      id-token: write
       contents: read
-      pull-requests: read
-      issues: read
-      administration: write
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -22,9 +26,8 @@ jobs:
           persist-credentials: false
 
       - name: Run opencode
-        uses: anomalyco/opencode/github@github-v1.2.22
+        uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: opencode/big-pickle


### PR DESCRIPTION
## Summary
- Fix opencode workflow permissions to resolve OIDC token errors
- Change `pull-requests: read` to `pull-requests: write`
- Change `issues: read` to `issues: write`
- Add `id-token: write` back for OIDC authentication

## Changes
- Updated permissions in `.github/workflows/opencode.yml`
- Uses `anomalyco/opencode/github@latest` (changed from specific version)

## Testing
- This PR can be used to test if the workflow triggers correctly on `/oc` comments
- If successful, the workflow should run opencode on comments starting with `/oc` or `/opencode`