### PR TITLE
Add use_github_token: true to opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -32,3 +32,4 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
           model: opencode/big-pickle
+          use_github_token: true


### PR DESCRIPTION
## Summary
- Add `use_github_token: true` to the opencode step in `.github/workflows/opencode.yml`
- This allows opencode to use `GITHUB_TOKEN` directly for GitHub API access

## Problem
The previous opencode workflow run (#26164450188) completed successfully but could not create a PR or add repository topics because `USE_GITHUB_TOKEN=false` meant `GH_TOKEN`/`GITHUB_TOKEN` were not exposed to the action runtime.

## Solution
Set `use_github_token: true` in the `with:` section of the opencode action, which maps to `USE_GITHUB_TOKEN: true` in the action's environment.

## Reference
From `anomalyco/opencode/github/action.yml`:
```yaml
use_github_token:
  description: "Use GITHUB_TOKEN directly instead of OpenCode App token exchange. When true, skips OIDC and uses the GITHUB_TOKEN env var."
  required: false
  default: "false"
```